### PR TITLE
Fixed scatters and waveseries plotters

### DIFF
--- a/dnplot/__init__.py
+++ b/dnplot/__init__.py
@@ -1,1 +1,1 @@
-from .plotters.plotters import Matplotlib, Plotly, Plotly1
+from .plotters.plotters import Matplotlib, Plotly

--- a/dnplot/__init__.py
+++ b/dnplot/__init__.py
@@ -1,1 +1,1 @@
-from .plotters.plotters import Matplotlib, Matplotlib1, Plotly, Plotly1
+from .plotters.plotters import Matplotlib, Plotly, Plotly1

--- a/dnplot/plot_functions/matplotlib_functions.py
+++ b/dnplot/plot_functions/matplotlib_functions.py
@@ -11,6 +11,7 @@ from scipy.stats import gaussian_kde
 from dnplot import sanitation 
 from dnplot.stats import calculate_RMSE, calculate_correlation
 import xarray as xr
+
 def grid_plotter(fig_dict: dict, data_dict: dict, coastline: bool = None) -> dict:
     """Plot the depth information and land mask. Also plots information about e.g. wind data and spectral points"""
     fig_dict = topo_plotter(fig_dict, data_dict, coastline=coastline)
@@ -244,109 +245,94 @@ def spectra_plotter(fig_dict: dict, model) -> dict:
     return fig_dict
 
 
-def waveseries_plotter(model, var: list[str]):
-    ts = model["waveseries"]
-    if len(var) < 4:
-        fig, axes = plt.subplots(len(var), 1)
-        fig.suptitle(ts.name, fontsize=16)
-        axes = axes if len(var) > 1 else [axes]
-        for i, item in enumerate(var):
-            if isinstance(item, tuple):
-                var1, var2 = item
-                ax = axes[i]
-                ax.plot(
-                    ts.get("time"),
-                    ts.get(var1),
-                    color="b",
-                    label=f"{var1} ({ts.meta.get(var1)['units']})",
-                )
+def waveseries_plotter(model, model1, var: list[str], separate_plots: bool):
+    """var = ['hs', 'tp'] or ['hs',('tp','tm01')]
 
-                ax.set_ylabel(
-                    f"{ts.meta.get(var1)['long_name']}\n ({ts.meta.get(var1)['units']})",
-                    color="b",
-                )
-                ax.set_xlabel("UTC", fontsize=12)
-                ax2 = ax.twinx()
-                ax2.plot(
-                    ts.get("time"),
-                    ts.get(var2),
-                    color="g",
-                    label=f"{var2} ({ts.meta.get(var2)['units']})",
-                )
-                ax2.set_ylabel(
-                    f"{ts.meta.get(var2)['long_name']}\n ({ts.meta.get(var2)['units']})",
-                    color="g",
-                )
-                lines1, labels1 = ax.get_legend_handles_labels()
-                lines2, labels2 = ax2.get_legend_handles_labels()
-                ax2.legend(lines1 + lines2, labels1 + labels2)
-                ax.grid(True)
+    use 'separate_plots = True' to get separate figures for each parameter.
+    Default is separate_plots = True for more than 4 parameters."""
+    
+    if separate_plots is None:
+        separate_plots = len(var) > 4
 
-            else:
-                axes[i].plot(
-                    ts.get("time"),
-                    ts.get(item),
-                    color="b",
-                    label=f"{item} ({ts.meta.get(item)['units']})",
-                )
-                axes[i].set_ylabel(
-                    f"{ts.meta.get(item)['long_name']} \n ({ts.meta.get(item)['units']})"
-                )
-                axes[i].set_xlabel("UTC", fontsize=12)
-                axes[i].legend()
-                axes[i].grid(True)
-        plt.tight_layout()
-        plt.show()
+    xmodel = sanitation.force_to_ds(model)
+    ymodel = sanitation.force_to_ds(model1)
 
+    if separate_plots:
+        axes = []
+        for i in range(len(var)):
+            __, ax = plt.subplots()
+            axes.append(ax)        
     else:
-        for item in var:
-            fig, ax = plt.subplots()
-            if isinstance(item, tuple):
-                var1, var2 = item
-                ax.plot(
+        __, axes = plt.subplots(len(var), 1)
+        axes = axes if len(var) > 1 else [axes]
+
+    # Get a list of axes, keeping in mind that we can have twin axes if we give a tuple ('tp','tm01') in vars        
+    list_of_axes = []
+    list_of_variables = []
+    list_of_colors = []
+    draw_legend = []
+    for i, axe in enumerate(axes):
+        list_of_axes.append(axe)
+        if isinstance(var[i], tuple) or isinstance(var[i], list):
+            list_of_axes.append(axe.twinx())
+            if len(var[i])>2:
+                raise ValueError(f"Can give a maximum of 2 parameters to plot in same plot! ({var[i]})")
+            list_of_variables.append(var[i][0])
+            list_of_variables.append(var[i][1])
+            list_of_colors.append(('b','r'))
+            list_of_colors.append(('g','m'))
+            draw_legend.append(False)
+            draw_legend.append(True)
+        else:
+            list_of_variables.append(var[i])
+            list_of_colors.append(('b','r'))
+            draw_legend.append(True)
+
+
+    lines, labels = [], []
+    for v, a, c, lgnd in zip(list_of_variables, list_of_axes, list_of_colors, draw_legend):
+        ylabel_set = False
+        for i, ts in enumerate([xmodel, ymodel]):
+
+            varname = sanitation.get_varname(ts,v)
+            unit = sanitation.get_units(ts,v)
+            
+            if ts.get(v) is not None:
+                a.plot(
                     ts.get("time"),
-                    ts.get(var1),
-                    color="b",
-                    label=f"{var1} ({ts.meta.get(var1)['units']})",
+                    ts.get(v),
+                    color=c[i],
+                    label=f"{ts.name} {v} ({unit})",
                 )
 
-                ax.set_ylabel(
-                    f"{ts.meta.get(var1)['long_name']}\n ({ts.meta.get(var1)['units']})",
-                    color="b",
-                )
-                ax.set_xlabel("UTC", fontsize=12)
-                ax2 = ax.twinx()
-                ax2.plot(
-                    ts.get("time"),
-                    ts.get(var2),
-                    color="g",
-                    label=f"{var2} ({ts.meta.get(var2)['units']})",
-                )
-                ax2.set_ylabel(
-                    f"{ts.meta.get(var2)['long_name']}\n ({ts.meta.get(var2)['units']})",
-                    color="g",
-                )
-                lines1, labels1 = ax.get_legend_handles_labels()
-                lines2, labels2 = ax2.get_legend_handles_labels()
-                ax2.legend(lines1 + lines2, labels1 + labels2)
-                ax.grid(True)
-            else:
-                ax.plot(
-                    ts.get("time"),
-                    ts.get(item),
-                    color="b",
-                    label=f"{item} ({ts.meta.get(item)['units']})",
-                )
-                ax.set_xlabel("UTC", fontsize=12)
-                ax.set_ylabel(
-                    f"{ts.meta.get(item)['long_name']} \n ({ts.meta.get(item)['units']})"
-                )
-                ax.legend()
-                ax.grid(True)
-            ax.set_title(ts.name, fontsize=16)
+                # Set it only once so we get the first color
+                if not ylabel_set:
+                    a.set_ylabel(
+                        f"{varname} ({unit})",
+                        color=c[0],
+                    )
+                    ylabel_set = True
 
-        plt.tight_layout()
-        plt.show()
+        # If not set, then set withouth data (then missing units etc.)
+        if not ylabel_set:
+            a.set_ylabel(
+                f"{varname} ({unit})",
+                color=c[0],
+            )
+        a.grid(True)
+        
+        # This is to handle twin axes correctly
+        li, la = a.get_legend_handles_labels()
+        lines += li
+        labels += la
+        if lgnd:
+            a.legend(lines, labels)
+            lines, labels = [], []
+        
+
+
+    plt.tight_layout()
+    plt.show()
 
 
 def spectra1d_plotter(fig_dict: dict, model) -> dict:

--- a/dnplot/plot_functions/matplotlib_functions.py
+++ b/dnplot/plot_functions/matplotlib_functions.py
@@ -8,7 +8,7 @@ from sklearn.linear_model import LinearRegression
 from matplotlib.colors import Normalize
 from matplotlib import cm
 from scipy.stats import gaussian_kde
-
+from dnplot import sanitation 
 from dnplot.stats import calculate_RMSE, calculate_correlation
 import xarray as xr
 def grid_plotter(fig_dict: dict, data_dict: dict, coastline: bool = None) -> dict:
@@ -436,48 +436,21 @@ def scatter_plotter(fig_dict: dict, model, var):
     plt.show(block=True)
 
 
-def xarray_to_dataframe(ds) -> pd.DataFrame:
-   
-    df = ds.to_dataframe()
-    df = df.reset_index()
-    col_drop = ["lon", "lat", "inds"]
-    df = df.drop(col_drop, axis="columns")
-    df.set_index("time", inplace=True)
-    df = df.resample("h").asfreq()
-    df = df.reset_index()
-    return df
 
 
 def scatter_plotter(fig_dict: dict, model, model1, xvar:str, yvar:str):
     """Plots a scatter plot of data from two different objects"""
     
   
-    xmodel = model.get('waveseries') or model
-    ymodel = model1.get('waveseries') or model1
-    if not isinstance(xmodel,xr.Dataset):
-        xmodel = xmodel.ds()
-    if not isinstance(ymodel,xr.Dataset):
-        ymodel = ymodel.ds()
+    xmodel = sanitation.force_to_ds(model)
+    ymodel = sanitation.force_to_ds(model1)
+    xunit = sanitation.get_units(xmodel,xvar)
+    yunit = sanitation.get_units(ymodel,yvar)
+    xvarname = sanitation.get_varname(xmodel,xvar)
+    yvarname = sanitation.get_varname(ymodel,yvar)
+    xdf = sanitation.xarray_to_dataframe(xmodel)
+    ydf = sanitation.xarray_to_dataframe(ymodel)
 
-    # Determine units
-
-    xunit = getattr(xmodel.get(xvar), 'units', '')
-    xvarname = (
-        getattr(xmodel.get(xvar), 'long_name', None) or
-        getattr(xmodel.get(xvar), 'standard_name', None) or
-        getattr(xmodel.get(xvar), 'short_name', xvar)
-    )
-
-
-    yunit = getattr(ymodel.get(yvar), 'units', '')
-    yvarname = (
-        getattr(ymodel.get(yvar), 'long_name', None) or
-        getattr(ymodel.get(yvar), 'standard_name', None) or
-        getattr(ymodel.get(yvar), 'short_name', yvar)
-    )
-
-    xdf = xarray_to_dataframe(xmodel)
-    ydf = xarray_to_dataframe(ymodel)
     combined_df = pd.concat([xdf, ydf], axis=1)
     combined_df_cleaned = combined_df.dropna()
 

--- a/dnplot/plot_functions/matplotlib_functions.py
+++ b/dnplot/plot_functions/matplotlib_functions.py
@@ -6,7 +6,7 @@ from ..defaults import default_variable, DEFAULT_VARIABLE_DATA
 import pandas as pd
 from sklearn.linear_model import LinearRegression
 from matplotlib.colors import Normalize
-from matplotlib import cm
+import cmocean.cm
 from scipy.stats import gaussian_kde
 from dnplot import sanitation 
 from dnplot.stats import calculate_RMSE, calculate_correlation
@@ -476,13 +476,11 @@ def scatter_plotter(fig_dict: dict, model, model1, xvar:str, yvar:str):
     xy = np.vstack([xdata, ydata])
     z = gaussian_kde(xy)(xy)
     norm = Normalize(vmin=z.min(), vmax=z.max())
-    cmap = cm.Blues
-    sm = cm.ScalarMappable(cmap=cmap, norm=norm)
-    sm.set_array([])
+    cmap = cmocean.cm.dense
 
     title = f"{xmodel.name} ({xvar}) vs {ymodel.name} ({yvar})"
     fig_dict["ax"].set_title(title, fontsize=14)
-    fig_dict["ax"].scatter(xdata, ydata, c=z, cmap=cmap,  norm=norm,s=50)
+    cont = fig_dict["ax"].scatter(xdata, ydata, c=z, cmap=cmap,  norm=norm,s=50)
     
     maxval = np.maximum(np.max(xdata), np.max(ydata))
     fig_dict["ax"].set_xlim([0, maxval])
@@ -490,14 +488,14 @@ def scatter_plotter(fig_dict: dict, model, model1, xvar:str, yvar:str):
 
     slope, intercept = np.polyfit(xdata, ydata,1)
     x_range = np.linspace(0, np.ceil(np.max(xdata)), 100)
-    fig_dict["ax"].plot(x_range, x_range, linewidth=0.5, color='k',label="x=y")
+    fig_dict["ax"].plot(x_range, x_range, linewidth=1, color='k',linestyle='--',label="x=y")
 
     sign = '+' if intercept >=0 else '-'
     fig_dict["ax"].plot(
-        x_range, slope*x_range+intercept, color="red", linewidth=2, label=f"Regression line y={slope:.2f}x{sign}{np.abs(intercept):.2f}"
+        x_range, slope*x_range+intercept, color="r", linewidth=2, label=f"Regression line y={slope:.2f}x{sign}{np.abs(intercept):.2f}"
     )
     slope_1p = np.mean(ydata)/np.mean(xdata)
-    fig_dict["ax"].plot(x_range, x_range*slope_1p, linewidth=2, color = 'm',label=f"One parameter line y={slope_1p:.2f}x ")
+    fig_dict["ax"].plot(x_range, x_range*slope_1p, linewidth=2, color = 'k',label=f"One parameter line y={slope_1p:.2f}x ")
 
     fig_dict["ax"].set_xlabel(
         f"{xmodel.name} {xvarname}\n ({xunit})"
@@ -507,7 +505,7 @@ def scatter_plotter(fig_dict: dict, model, model1, xvar:str, yvar:str):
     )
 
     # color bar
-    cbar = plt.colorbar(sm, ax=fig_dict["ax"])
+    cbar = plt.colorbar(cont, ax=fig_dict["ax"])
     cbar.set_label("Density", rotation=270, labelpad=15)
 
     props = dict(boxstyle="square", facecolor="white", alpha=0.6)

--- a/dnplot/plot_functions/matplotlib_functions.py
+++ b/dnplot/plot_functions/matplotlib_functions.py
@@ -9,6 +9,7 @@ from matplotlib.colors import Normalize
 from matplotlib import cm
 from scipy.stats import gaussian_kde
 
+from dnplot.stats import calculate_RMSE, calculate_correlation
 
 def grid_plotter(fig_dict: dict, data_dict: dict, coastline: bool = None) -> dict:
     """Plot the depth information and land mask. Also plots information about e.g. wind data and spectral points"""
@@ -446,103 +447,83 @@ def xarray_to_dataframe(model) -> pd.DataFrame:
     return df
 
 
-def calculate_correlation(x, y):
-    x_mean = x.mean()
-    y_mean = y.mean()
-    covariance = ((x - x_mean) * (y - y_mean)).mean()
-    x_var = ((x - x_mean) ** 2).mean()
-    y_var = ((y - y_mean) ** 2).mean()
-    x_std = x_var**0.5
-    y_std = y_var**0.5
-    correlation = covariance / (x_std * y_std)
-    return correlation
-
-
-def calculate_RMSE(x, y):
-    X = x.values.reshape(-1, 1)
-    linear = LinearRegression()
-    linear.fit(X, y)
-    a = linear.coef_[0]
-    b = linear.intercept_
-    y_estimated = a * x + b
-    y_rmse = (y - y_estimated) ** 2
-    RMSE = (y_rmse.mean()) ** 0.5
-    return RMSE
-
-
-def scatter1_plotter(fig_dict: dict, model, model1, var):
-    ds_model = model.waveseries()
-    ds1_model1 = model1.waveseries()
-    x = var[0]
-    y = var[1]
-    df_model = xarray_to_dataframe(ds_model)
-    df1_model1 = xarray_to_dataframe(ds1_model1)
-    combined_df = pd.concat([df_model, df1_model1], axis=1)
-
+def scatter_plotter(fig_dict: dict, model, model1, xvar:str, yvar:str):
+    """Plots a scatter plot of data from two different objects"""
+    
+  
+    xmodel = model.get('waveseries')
+    ymodel = model1.get('waveseries')
+    
+    xdf = xarray_to_dataframe(xmodel)
+    ydf = xarray_to_dataframe(ymodel)
+    combined_df = pd.concat([xdf, ydf], axis=1)
     combined_df_cleaned = combined_df.dropna()
 
-    df_model = combined_df_cleaned.iloc[:, : df_model.shape[1]].reset_index(drop=True)
-    df1_model1 = combined_df_cleaned.iloc[:, df_model.shape[1] :].reset_index(drop=True)
-    correlation = calculate_correlation(df_model[x], df1_model1[y])
+    xdf = combined_df_cleaned.iloc[:, : xdf.shape[1]].reset_index(drop=True)
+    ydf = combined_df_cleaned.iloc[:, xdf.shape[1] :].reset_index(drop=True)
 
-    RMSE = calculate_RMSE(df_model[x], df1_model1[y])
-    SI = RMSE / df_model[x].mean()
-    X = df_model[x].values.reshape(-1, 1)
-    linear = LinearRegression()
-    linear.fit(X, df1_model1[y])
+    xdata, ydata = xdf[xvar], ydf[yvar]
+    # Determine units
+    if hasattr(xmodel, 'meta'):
+        if xmodel.meta.get(xvar) is not None:
+            xunit = xmodel.meta.get(xvar).get('units','')
+            xvarname = xmodel.meta.get(xvar).get('long_name',xvar)
+    else:
+        xunit = ''
+        xvarname = xvar
+    if hasattr(ymodel, 'meta'):
+        if ymodel.meta.get(yvar) is not None:
+            yunit = xmodel.meta.get(yvar).get('units','')
+            yvarname = xmodel.meta.get(yvar).get('long_name',yvar)
+    else:
+        yunit=''
+        yvarname = yvar
 
-    x_range = np.linspace(0, np.ceil(X.max()), 100)
-    y_range = linear.predict(x_range.reshape(-1, 1))
+    # Statistics
+    RMSE = np.sqrt(np.mean((xdata-ydata)**2))
+    R = np.corrcoef(xdata, ydata)[0,1]
+    SI = RMSE / np.mean(xdata)*100
     # Text on the figure
-    text = "\n".join(
-        (
-            f"N={len(df_model)}",
-            f"Bias{df_model[x].mean() - df1_model1[y].mean():.4f}",
-            f"R\u00b2={correlation:.4f}",
-            f"RMSE={RMSE:.4f}",
-            f"SI={SI:.4f}",
-        )
-    )
+    text = [f"N={len(xdf)}"]
+    if xunit == yunit:
+        text.append(f"Bias={np.mean(xdata)-np.mean(ydata):.2f}{xunit}")
+        text.append(f"RMSE={RMSE:.2f}{xunit}")
+        text.append(f"SI={SI:.0f}%")
+    text.append(f"r={R:.2f}")
+    text = '\n'.join(text)
+
     # color for scatter density
-    xy = np.vstack([df_model[x].values, df1_model1[y].values])
+    xy = np.vstack([xdata, ydata])
     z = gaussian_kde(xy)(xy)
     norm = Normalize(vmin=z.min(), vmax=z.max())
-    cmap = cm.jet
+    cmap = cm.Blues
     sm = cm.ScalarMappable(cmap=cmap, norm=norm)
     sm.set_array([])
 
-    title = rf"$\bf{{{ds_model.name}}}$" + "\n" + rf"{x} vs {y}"
+    title = f"{xmodel.name} ({xvar}) vs {ymodel.name} ({yvar})"
     fig_dict["ax"].set_title(title, fontsize=14)
-    fig_dict["ax"].scatter(df_model[x], df1_model1[y], c=z, cmap=cmap, norm=norm, s=50)
-    x_max = np.ceil(df_model[x].max())
-    y_max = np.ceil(df1_model1[y].max())
+    fig_dict["ax"].scatter(xdata, ydata, c=z, cmap=cmap,  norm=norm,s=50)
+    
+    maxval = np.maximum(np.max(xdata), np.max(ydata))
+    fig_dict["ax"].set_xlim([0, maxval])
+    fig_dict["ax"].set_ylim([0, maxval])
 
-    if x_max > y_max:
-        fig_dict["ax"].set_ylim([0, x_max])
-        fig_dict["ax"].set_xlim([0, x_max])
-    else:
-        fig_dict["ax"].set_xlim([0, y_max])
-        fig_dict["ax"].set_ylim([0, y_max])
+    slope, intercept = np.polyfit(xdata, ydata,1)
+    x_range = np.linspace(0, np.ceil(np.max(xdata)), 100)
+    fig_dict["ax"].plot(x_range, x_range, linewidth=0.5, color='k',label="x=y")
 
+    sign = 'x' if intercept >=0 else '-'
     fig_dict["ax"].plot(
-        x_range, y_range, color="red", linewidth=2, label="Regression line"
+        x_range, slope*x_range+intercept, color="red", linewidth=2, label=f"Regression line y={slope:.2f}x{sign}{np.abs(intercept):.2f}"
     )
-
-    x_line = np.linspace(0, np.ceil(df_model[x].max()), 100)
-    a = np.sum(df_model[x] * df1_model1[y]) / np.sum(df_model[x] ** 2)
-    y_line = a * x_line
-
-    fig_dict["ax"].plot(x_line, y_line, linewidth=2, label="One parameter line")
-
-    x_values = np.linspace(0, np.ceil(df_model[x].max()), 100)
-    y_values = x_values
-    fig_dict["ax"].plot(x_values, y_values, linewidth=2, label="x=y")
+    slope_1p = np.mean(ydata)/np.mean(xdata)
+    fig_dict["ax"].plot(x_range, x_range*slope_1p, linewidth=2, color = 'm',label=f"One parameter line y={slope_1p:.2f}x ")
 
     fig_dict["ax"].set_xlabel(
-        f"{ds_model.meta.get(x)['long_name']}\n ({ds_model.meta.get(x)['units']})"
+        f"{xmodel.name} {xvarname}\n ({xunit})"
     )
     fig_dict["ax"].set_ylabel(
-        f"{ds1_model1.meta.get(y)['long_name']}\n ({ds1_model1.meta.get(y)['units']})"
+        f"{ymodel.name} {yvarname}\n ({yunit})"
     )
 
     # color bar
@@ -550,13 +531,13 @@ def scatter1_plotter(fig_dict: dict, model, model1, var):
     cbar.set_label("Density", rotation=270, labelpad=15)
 
     props = dict(boxstyle="square", facecolor="white", alpha=0.6)
-    ax = plt.gca()
+    ax = fig_dict["ax"]
     fig_dict["ax"].text(
-        0.005,
-        0.90,
+        0.05,
+        0.7,
         text,
         bbox=props,
-        fontsize=12,
+        fontsize=10,
         transform=ax.transAxes,
         verticalalignment="top",
         horizontalalignment="left",

--- a/dnplot/plot_functions/matplotlib_functions.py
+++ b/dnplot/plot_functions/matplotlib_functions.py
@@ -451,8 +451,8 @@ def scatter_plotter(fig_dict: dict, model, model1, xvar:str, yvar:str):
     """Plots a scatter plot of data from two different objects"""
     
   
-    xmodel = model.get('waveseries')
-    ymodel = model1.get('waveseries')
+    xmodel = model.get('waveseries') or model
+    ymodel = model1.get('waveseries') or model1
     
     xdf = xarray_to_dataframe(xmodel)
     ydf = xarray_to_dataframe(ymodel)
@@ -512,7 +512,7 @@ def scatter_plotter(fig_dict: dict, model, model1, xvar:str, yvar:str):
     x_range = np.linspace(0, np.ceil(np.max(xdata)), 100)
     fig_dict["ax"].plot(x_range, x_range, linewidth=0.5, color='k',label="x=y")
 
-    sign = 'x' if intercept >=0 else '-'
+    sign = '+' if intercept >=0 else '-'
     fig_dict["ax"].plot(
         x_range, slope*x_range+intercept, color="red", linewidth=2, label=f"Regression line y={slope:.2f}x{sign}{np.abs(intercept):.2f}"
     )

--- a/dnplot/plot_functions/matplotlib_functions.py
+++ b/dnplot/plot_functions/matplotlib_functions.py
@@ -10,7 +10,7 @@ from matplotlib import cm
 from scipy.stats import gaussian_kde
 
 from dnplot.stats import calculate_RMSE, calculate_correlation
-
+import xarray as xr
 def grid_plotter(fig_dict: dict, data_dict: dict, coastline: bool = None) -> dict:
     """Plot the depth information and land mask. Also plots information about e.g. wind data and spectral points"""
     fig_dict = topo_plotter(fig_dict, data_dict, coastline=coastline)
@@ -436,8 +436,9 @@ def scatter_plotter(fig_dict: dict, model, var):
     plt.show(block=True)
 
 
-def xarray_to_dataframe(model) -> pd.DataFrame:
-    df = model.ds().to_dataframe()
+def xarray_to_dataframe(ds) -> pd.DataFrame:
+   
+    df = ds.to_dataframe()
     df = df.reset_index()
     col_drop = ["lon", "lat", "inds"]
     df = df.drop(col_drop, axis="columns")
@@ -453,7 +454,28 @@ def scatter_plotter(fig_dict: dict, model, model1, xvar:str, yvar:str):
   
     xmodel = model.get('waveseries') or model
     ymodel = model1.get('waveseries') or model1
-    
+    if not isinstance(xmodel,xr.Dataset):
+        xmodel = xmodel.ds()
+    if not isinstance(ymodel,xr.Dataset):
+        ymodel = ymodel.ds()
+
+    # Determine units
+
+    xunit = getattr(xmodel.get(xvar), 'units', '')
+    xvarname = (
+        getattr(xmodel.get(xvar), 'long_name', None) or
+        getattr(xmodel.get(xvar), 'standard_name', None) or
+        getattr(xmodel.get(xvar), 'short_name', xvar)
+    )
+
+
+    yunit = getattr(ymodel.get(yvar), 'units', '')
+    yvarname = (
+        getattr(ymodel.get(yvar), 'long_name', None) or
+        getattr(ymodel.get(yvar), 'standard_name', None) or
+        getattr(ymodel.get(yvar), 'short_name', yvar)
+    )
+
     xdf = xarray_to_dataframe(xmodel)
     ydf = xarray_to_dataframe(ymodel)
     combined_df = pd.concat([xdf, ydf], axis=1)
@@ -463,21 +485,6 @@ def scatter_plotter(fig_dict: dict, model, model1, xvar:str, yvar:str):
     ydf = combined_df_cleaned.iloc[:, xdf.shape[1] :].reset_index(drop=True)
 
     xdata, ydata = xdf[xvar], ydf[yvar]
-    # Determine units
-    if hasattr(xmodel, 'meta'):
-        if xmodel.meta.get(xvar) is not None:
-            xunit = xmodel.meta.get(xvar).get('units','')
-            xvarname = xmodel.meta.get(xvar).get('long_name',xvar)
-    else:
-        xunit = ''
-        xvarname = xvar
-    if hasattr(ymodel, 'meta'):
-        if ymodel.meta.get(yvar) is not None:
-            yunit = xmodel.meta.get(yvar).get('units','')
-            yvarname = xmodel.meta.get(yvar).get('long_name',yvar)
-    else:
-        yunit=''
-        yvarname = yvar
 
     # Statistics
     RMSE = np.sqrt(np.mean((xdata-ydata)**2))

--- a/dnplot/plot_functions/matplotlib_functions.py
+++ b/dnplot/plot_functions/matplotlib_functions.py
@@ -245,7 +245,7 @@ def spectra_plotter(fig_dict: dict, model) -> dict:
     return fig_dict
 
 
-def waveseries_plotter(model, model1, var: list[str], separate_plots: bool):
+def waveseries_plotter(model, model1, var: list[str], lon:float, lat:float, separate_plots: bool):
     """var = ['hs', 'tp'] or ['hs',('tp','tm01')]
 
     use 'separate_plots = True' to get separate figures for each parameter.
@@ -256,14 +256,28 @@ def waveseries_plotter(model, model1, var: list[str], separate_plots: bool):
 
     xmodel = sanitation.force_to_ds(model)
     ymodel = sanitation.force_to_ds(model1)
+    
+    if lon is not None and lat is not None:
+        distances = np.sqrt((xmodel["lon"] - lon)**2 + (xmodel["lat"] - lat)**2)
+        nearest_index = distances.argmin().item()
+        xmodel = xmodel.isel(inds=nearest_index)
+        if ymodel is not None:
+            distances = np.sqrt((ymodel["lon"] - lon)**2 + (ymodel["lat"] - lat)**2)
+            nearest_index = distances.argmin().item()
+            ymodel = ymodel.isel(inds=nearest_index)
+    
+        
 
     if separate_plots:
         axes = []
         for i in range(len(var)):
-            __, ax = plt.subplots()
-            axes.append(ax)        
+            fig, ax = plt.subplots()
+            axes.append(ax)
+
+            fig.suptitle(f"lat: {xmodel.lat:.4f}, lon: {xmodel.lon:.4f}")
     else:
-        __, axes = plt.subplots(len(var), 1)
+        fig, axes = plt.subplots(len(var), 1)
+        fig.suptitle(f"lat: {xmodel.lat:.4f}, lon: {xmodel.lon:.4f}")
         axes = axes if len(var) > 1 else [axes]
 
     # Get a list of axes, keeping in mind that we can have twin axes if we give a tuple ('tp','tm01') in vars        
@@ -293,25 +307,25 @@ def waveseries_plotter(model, model1, var: list[str], separate_plots: bool):
     for v, a, c, lgnd in zip(list_of_variables, list_of_axes, list_of_colors, draw_legend):
         ylabel_set = False
         for i, ts in enumerate([xmodel, ymodel]):
-
-            varname = sanitation.get_varname(ts,v)
-            unit = sanitation.get_units(ts,v)
-            
-            if ts.get(v) is not None:
-                a.plot(
-                    ts.get("time"),
-                    ts.get(v),
-                    color=c[i],
-                    label=f"{ts.name} {v} ({unit})",
-                )
-
-                # Set it only once so we get the first color
-                if not ylabel_set:
-                    a.set_ylabel(
-                        f"{varname} ({unit})",
-                        color=c[0],
+            if ts is not None:
+                varname = sanitation.get_varname(ts,v)
+                unit = sanitation.get_units(ts,v)
+                
+                if ts.get(v) is not None:
+                    a.plot(
+                        ts.get("time"),
+                        ts.get(v),
+                        color=c[i],
+                        label=f"{ts.name} {v} ({unit})",
                     )
-                    ylabel_set = True
+
+                    # Set it only once so we get the first color
+                    if not ylabel_set:
+                        a.set_ylabel(
+                            f"{varname} ({unit})",
+                            color=c[0],
+                        )
+                        ylabel_set = True
 
         # If not set, then set withouth data (then missing units etc.)
         if not ylabel_set:

--- a/dnplot/plot_functions/plotly_functions.py
+++ b/dnplot/plot_functions/plotly_functions.py
@@ -144,23 +144,37 @@ def open_browser(port):
         webbrowser.open_new(f"http://127.0.0.1:{port}/")
 
 
-def waveseries_plotter_basic(model):
-    ts = model["waveseries"]
+def waveseries_plotter_basic(model, model1):
+    xmodel = sanitation.force_to_ds(model)
+    xdf = sanitation.xarray_to_dataframe(xmodel)
+    ymodel = sanitation.force_to_ds(model1)
+    if ymodel is not None:
+        ydf = sanitation.xarray_to_dataframe(ymodel)
+
+    if ymodel is not None:
+        df = pd.merge(
+            xdf.set_index("time").add_suffix(f" {xmodel.name}").reset_index(),
+            ydf.set_index("time").add_suffix(f" {ymodel.name}").reset_index(),
+            on="time",
+        )
+    else:
+        df = xdf
+
+
     fig = go.Figure()
 
-    variables = [col for col in ts.core.data_vars()]
-
+    variables = [col for col in df if col != 'time']
     for variable in variables:
         trace = go.Scatter(
-            x=ts.get("time"),
-            y=ts.get(variable),
+            x=df["time"],
+            y=df[variable],
             mode="lines",
             name=variable,
             visible="legendonly",
         )
         fig.add_trace(trace)
 
-    fig.update_layout(title=f"{ts.name}", xaxis_title="UTC", yaxis_title="Values")
+    fig.update_layout(title=f"{xmodel.name}", xaxis_title="UTC", yaxis_title="Values")
     fig.show()
 
 
@@ -264,11 +278,11 @@ def waveseries_plotter_dash(model):
     app.run(debug=False, port=port)
 
 
-def waveseries_plotter(model, use_dash: bool):
+def waveseries_plotter(model, model1, use_dash: bool):
     if use_dash:
         waveseries_plotter_dash(model)
     else:
-        waveseries_plotter_basic(model)
+        waveseries_plotter_basic(model, model1)
 
 
 def create_spectra_app_layout(

--- a/dnplot/plot_functions/plotly_functions.py
+++ b/dnplot/plot_functions/plotly_functions.py
@@ -3,7 +3,7 @@ from plotly.subplots import make_subplots
 import plotly.express as px
 import numpy as np
 import pandas as pd
-from sklearn.linear_model import LinearRegression
+
 import plotly.graph_objects as go
 from scipy.stats import gaussian_kde
 import os
@@ -24,28 +24,6 @@ def xarray_to_dataframe(model) -> pd.DataFrame:
     return df
 
 
-def calculate_correlation(x, y):
-    x_mean = x.mean()
-    y_mean = y.mean()
-    covariance = ((x - x_mean) * (y - y_mean)).mean()
-    x_var = ((x - x_mean) ** 2).mean()
-    y_var = ((y - y_mean) ** 2).mean()
-    x_std = x_var**0.5
-    y_std = y_var**0.5
-    correlation = covariance / (x_std * y_std)
-    return correlation
-
-
-def calculate_RMSE(x, y):
-    X = x.values.reshape(-1, 1)
-    linear = LinearRegression()
-    linear.fit(X, y)
-    a = linear.coef_[0]
-    b = linear.intercept_
-    y_estimated = a * x + b
-    y_rmse = (y - y_estimated) ** 2
-    RMSE = (y_rmse.mean()) ** 0.5
-    return RMSE
 
 
 def linear_regression_line(x, y, fig):

--- a/dnplot/plot_functions/plotly_functions.py
+++ b/dnplot/plot_functions/plotly_functions.py
@@ -13,6 +13,7 @@ import random
 from flask import Flask
 from dnplot.stats import calculate_correlation, calculate_RMSE
 from dnplot import sanitation
+import cmocean.cm
 def xarray_to_dataframe(model) -> pd.DataFrame:
     df = model.ds().to_dataframe()
     df = df.reset_index()
@@ -498,47 +499,45 @@ def scatter_plotter(model, model1):
 
         if xvar not in df.columns or yvar not in df.columns:
             return go.Figure()
+        
+        # Add scatter
+        xunit = sanitation.get_units(xmodel,xvar.split(' ')[0])
+        yunit = sanitation.get_units(ymodel,yvar.split(' ')[0])
         fig = px.scatter(
-            df_noNa, x=xvar, y=yvar, color=z, color_continuous_scale="jet"
+           df_noNa, x=xvar, y=yvar, color=z, color_continuous_scale='blues', labels={
+                xvar: f"{xvar} ({xunit})",
+                yvar: f"{yvar} ({yunit})"}
         )
 
         linear_regression_line(xdata, ydata, fig)
 
-        x_max = np.ceil(np.max(xdata))
-        y_max = np.ceil(np.max(ydata))
-
-        x_values = np.linspace(0, np.ceil(x_max), 100)
-        y_values = x_values
+        # Lines
+        x_values = np.linspace(0, np.ceil(np.max(xdata)), 100)
+       
         fig.add_traces(
             go.Scatter(
-                x=x_values, y=y_values, mode="lines", name="x=y", visible="legendonly"
+                x=x_values, y=x_values, mode="lines", name="x=y", visible="legendonly"
             )
         )
-
-        x_line = np.linspace(0, np.ceil(x_max), 100)
+        
         a = np.mean(ydata)/np.mean(xdata)
-        y = a * x_line
         fig.add_traces(
             go.Scatter(
-                x=x_line,
-                y=y,
+                x=x_values,
+                y=a * x_values,
                 mode="lines",
                 name="one-parameter-linear regression",
                 visible="legendonly",
             )
         )
 
-        if x_max > y_max:
-            fig.update_layout(
-                yaxis=dict(range=[0, x_max]), xaxis=dict(range=[0, x_max])
-            )
-        else:
-            fig.update_layout(
-                xaxis=dict(range=[0, y_max]), yaxis=dict(range=[0, y_max])
-            )
+        maxval = np.maximum(np.max(xdata), np.max(ydata))
+        fig.update_layout(
+            yaxis=dict(range=[0, maxval]), xaxis=dict(range=[0, maxval])
+        )
+
         
-        xunit = sanitation.get_units(xmodel,xvar.split(' ')[0])
-        yunit = sanitation.get_units(ymodel,yvar.split(' ')[0])
+
         xvarname = sanitation.get_varname(xmodel,xvar.split(' ')[0])
         yvarname = sanitation.get_varname(ymodel,yvar.split(' ')[0])
         text = [f"N={len(xdf)}"]
@@ -547,7 +546,7 @@ def scatter_plotter(model, model1):
             text.append(f"RMSE={RMSE:.2f}{xunit}")
             text.append(f"SI={SI:.0f}%")
         text.append(f"r={R:.2f}")
-        text = '\n'.join(text)
+        text = '; '.join(text)
 
         fig.update_layout(
             coloraxis_colorbar=dict(title="Density", y=0.45, x=1.015, len=0.9),

--- a/dnplot/plot_functions/plotly_functions.py
+++ b/dnplot/plot_functions/plotly_functions.py
@@ -3,7 +3,7 @@ from plotly.subplots import make_subplots
 import plotly.express as px
 import numpy as np
 import pandas as pd
-
+from sklearn.linear_model import LinearRegression
 import plotly.graph_objects as go
 from scipy.stats import gaussian_kde
 import os
@@ -11,8 +11,8 @@ from threading import Timer
 import webbrowser
 import random
 from flask import Flask
-
-
+from dnplot.stats import calculate_correlation, calculate_RMSE
+from dnplot import sanitation
 def xarray_to_dataframe(model) -> pd.DataFrame:
     df = model.ds().to_dataframe()
     df = df.reset_index()
@@ -26,16 +26,13 @@ def xarray_to_dataframe(model) -> pd.DataFrame:
 
 
 
-def linear_regression_line(x, y, fig):
-    X = x.values.reshape(-1, 1)
-    linear = LinearRegression()
-    linear.fit(X, y)
-    x_range = np.linspace(0, np.ceil(X.max()), 100)
-    y_range = linear.predict(x_range.reshape(-1, 1))
+def linear_regression_line(xdata, ydata, fig):
+    slope, intercept = np.polyfit(xdata, ydata,1)
+    x_range = np.linspace(0, np.ceil(np.max(xdata)), 100)
     fig.add_traces(
         go.Scatter(
-            x=x_range.flatten(),
-            y=y_range.flatten(),
+            x=x_range,
+            y=x_range*slope+intercept,
             mode="lines",
             name="Linear regression",
             visible=True,
@@ -263,7 +260,7 @@ def waveseries_plotter_dash(model):
 
     port = random.randint(1000, 9999)
     Timer(1, open_browser, args=[port]).start()
-    app.run_server(debug=False, port=port)
+    app.run(debug=False, port=port)
 
 
 def waveseries_plotter(model, use_dash: bool):
@@ -444,43 +441,41 @@ def spectra_plotter(model):
 
     port = random.randint(1000, 9999)
     Timer(1, open_browser, args=[port]).start()
-    app.run_server(debug=False, port=port)
+    app.run(debug=False, port=port)
 
 
 def scatter_plotter(model, model1):
-    ds_model = model["waveseries"]
-    ds1_model1 = model1["waveseries"]
-    df_model = xarray_to_dataframe(model["waveseries"])
-    df1_model1 = xarray_to_dataframe(model1["waveseries"])
+    xmodel = sanitation.force_to_ds(model)
+    ymodel = sanitation.force_to_ds(model1)
+    xdf = sanitation.xarray_to_dataframe(xmodel)
+    ydf = sanitation.xarray_to_dataframe(ymodel)
 
-    common_columns = list(set(df_model.columns).intersection(set(df1_model1.columns)))
     df = pd.merge(
-        df_model[common_columns],
-        df1_model1[common_columns],
+        xdf.set_index("time").add_suffix(f" {xmodel.name}").reset_index(),
+        ydf.set_index("time").add_suffix(f" {ymodel.name}").reset_index(),
         on="time",
-        suffixes=(f" {ds_model.name}", f" {ds1_model1.name}"),
     )
     first_column = df.pop("time")
     df.insert(0, "time", first_column)
-    df_column = [col for col in df.columns if col.endswith(f" {ds_model.name}")]
-    df1_column = [col for col in df.columns if col.endswith(f" {ds1_model1.name}")]
+    df_column = [col for col in df.columns if col.endswith(f" {xmodel.name}")]
+    df1_column = [col for col in df.columns if col.endswith(f" {ymodel.name}")]
     df_noNa = df.dropna().reset_index(drop=True)
     app = Dash(__name__)
     app.layout = html.Div(
         [
-            html.H1(ds_model.name, style={"textAlign": "center"}),
+            html.H1(xmodel.name, style={"textAlign": "center"}),
             html.P("Select variable:"),
             dcc.Dropdown(
                 id="x-axis-dropdown",
                 options=[{"label": col, "value": col} for col in df_column],
-                value=f"hs {ds_model.name}",
+                value=f"hs {xmodel.name}",
                 clearable=False,
                 style={"width": "30%"},
             ),
             dcc.Dropdown(
                 id="y-axis-dropdown",
                 options=[{"label": col, "value": col} for col in df1_column],
-                value=f"hs {ds1_model1.name}",
+                value=f"hs {ymodel.name}",
                 clearable=False,
                 style={"width": "30%"},
             ),
@@ -493,36 +488,24 @@ def scatter_plotter(model, model1):
         Input("x-axis-dropdown", "value"),
         Input("y-axis-dropdown", "value"),
     )
-    def update_graph(x_var, y_var):
-        x_col = f"{x_var}"
-        y_col = f"{y_var}"
-        """
-        Calculates the correlation
-        """
-        correlation = calculate_correlation(df_noNa[x_col], df_noNa[y_col])
-        """
-        Calculates RMSE
-        Calculates SI
-        """
-        RMSE = calculate_RMSE(df_noNa[x_col], df_noNa[y_col])
-        SI = RMSE / df_noNa[x_col].mean()
-        """
-        Stack values and
-        Calculates density.
-        """
-        xy = np.vstack([df_noNa[x_col].values, df_noNa[y_col].values])
+    def update_graph(xvar, yvar):
+        xdata, ydata = df_noNa[xvar].values, df_noNa[yvar].values
+        RMSE = np.sqrt(np.mean((xdata-ydata)**2))
+        R = np.corrcoef(xdata, ydata)[0,1]
+        SI = RMSE / np.mean(xdata)*100
+        xy = np.vstack([xdata, ydata])
         z = gaussian_kde(xy)(xy)
 
-        if x_col not in df.columns or y_col not in df.columns:
+        if xvar not in df.columns or yvar not in df.columns:
             return go.Figure()
         fig = px.scatter(
-            df_noNa, x=x_col, y=y_col, color=z, color_continuous_scale="jet"
+            df_noNa, x=xvar, y=yvar, color=z, color_continuous_scale="jet"
         )
 
-        linear_regression_line(df_noNa[x_col], df_noNa[y_col], fig)
+        linear_regression_line(xdata, ydata, fig)
 
-        x_max = np.ceil(df_noNa[x_col].max())
-        y_max = np.ceil(df_noNa[y_col].max())
+        x_max = np.ceil(np.max(xdata))
+        y_max = np.ceil(np.max(ydata))
 
         x_values = np.linspace(0, np.ceil(x_max), 100)
         y_values = x_values
@@ -533,7 +516,7 @@ def scatter_plotter(model, model1):
         )
 
         x_line = np.linspace(0, np.ceil(x_max), 100)
-        a = np.sum(df_noNa[x_col] * df_noNa[y_col]) / np.sum(df_noNa[x_col] ** 2)
+        a = np.mean(ydata)/np.mean(xdata)
         y = a * x_line
         fig.add_traces(
             go.Scatter(
@@ -553,6 +536,19 @@ def scatter_plotter(model, model1):
             fig.update_layout(
                 xaxis=dict(range=[0, y_max]), yaxis=dict(range=[0, y_max])
             )
+        
+        xunit = sanitation.get_units(xmodel,xvar.split(' ')[0])
+        yunit = sanitation.get_units(ymodel,yvar.split(' ')[0])
+        xvarname = sanitation.get_varname(xmodel,xvar.split(' ')[0])
+        yvarname = sanitation.get_varname(ymodel,yvar.split(' ')[0])
+        text = [f"N={len(xdf)}"]
+        if xunit == yunit:
+            text.append(f"Bias={np.mean(xdata)-np.mean(ydata):.2f}{xunit}")
+            text.append(f"RMSE={RMSE:.2f}{xunit}")
+            text.append(f"SI={SI:.0f}%")
+        text.append(f"r={R:.2f}")
+        text = '\n'.join(text)
+
         fig.update_layout(
             coloraxis_colorbar=dict(title="Density", y=0.45, x=1.015, len=0.9),
             annotations=[
@@ -561,13 +557,7 @@ def scatter_plotter(model, model1):
                     y=0.995,
                     xref="paper",
                     yref="paper",
-                    text=(
-                        f"N = {len(df_noNa[x_col])}<br>"
-                        f"Bias = {df_noNa[x_col].mean() - df_noNa[y_col].mean():.4f}<br>"
-                        f"R\u00b2= {correlation:.4f}<br>"
-                        f"RMSE= {RMSE:.4F}<br>"
-                        f"SI= {SI:.4F}"
-                    ),
+                    text=text,
                     showarrow=False,
                     font=dict(size=16, color="black"),
                     align="left",
@@ -583,4 +573,4 @@ def scatter_plotter(model, model1):
 
     port = random.randint(1000, 9999)
     Timer(1, open_browser, args=[port]).start()
-    app.run_server(debug=False, port=port)
+    app.run(debug=False, port=port)

--- a/dnplot/plot_functions/plotly_functions.py
+++ b/dnplot/plot_functions/plotly_functions.py
@@ -178,9 +178,47 @@ def waveseries_plotter_basic(model, model1):
     fig.show()
 
 
-def waveseries_plotter_dash(model):
-    ts = model["waveseries"]
-    var = xarray_to_dataframe(ts)
+
+
+def waveseries_plotter_dash(model, model1):
+    xmodel_all = sanitation.force_to_ds(model)
+    
+    
+    xlon, xlat = xmodel_all.lon.values, xmodel_all.lat.values
+    
+    ymodel_all = sanitation.force_to_ds(model1)
+
+
+    
+    
+    xmodel = xmodel_all.sel(inds=0)
+    xdf = sanitation.xarray_to_dataframe(xmodel)
+    if ymodel_all is not None:
+        ylon, ylat = ymodel_all.lon.values, ymodel_all.lat.values
+        ymodel = ymodel_all.sel(inds=0)
+    else:
+        ymodel = None
+        
+    
+    
+    if ymodel is not None:
+        
+        ydf = sanitation.xarray_to_dataframe(ymodel)
+        xdf = xdf.set_index("time").add_suffix(f" {xmodel.name}").reset_index()
+        ydf = ydf.set_index("time").add_suffix(f" {ymodel.name}").reset_index()
+        df =  pd.merge(xdf,ydf,on="time")
+    else:
+        ydf = xdf
+        df = xdf
+
+
+    xvariables = [col for col in xdf if col != 'time']
+    yvariables = [col for col in ydf if col != 'time']
+    x_start_val = xvariables[0]
+    if ymodel is not None:
+        y_start_val = yvariables[0]
+    else:
+        y_start_val = 'None'
 
     app = Dash(__name__)
     app.layout = html.Div(
@@ -189,16 +227,16 @@ def waveseries_plotter_dash(model):
             html.P("Select variable:"),
             dcc.Dropdown(
                 id="waveseries-1",
-                options=[{"label": val, "value": val} for val in ts.core.data_vars()],
-                value="hs",
+                options=[{"label": val, "value": val} for val in xvariables],
+                value=x_start_val,
                 clearable=False,
                 style={"width": "30%"},
             ),
             dcc.Dropdown(
                 id="waveseries-2",
                 options=[{"label": "None", "value": "None"}]
-                + [{"label": val, "value": val} for val in ts.core.data_vars()],
-                value="None",
+                + [{"label": val, "value": val} for val in yvariables],
+                value=y_start_val,
                 clearable=False,
                 style={"width": "30%"},
             ),
@@ -212,6 +250,30 @@ def waveseries_plotter_dash(model):
                     "width": "75",
                     "float": "left",
                 },
+            ),
+            html.Label(f"{xmodel.name}"),
+            dcc.Slider(
+                min=0,
+                max=len(xlon),
+                step=1,
+                value=0,
+                tooltip={"placement": "bottom", "always_visible": True},
+                updatemode="drag",
+                persistence=True,
+                persistence_type="session",
+                id="xslider",
+            ),
+            html.Label(f"{ymodel.name}"),
+            dcc.Slider(
+                min=0,
+                max=len(ylon),
+                step=1,
+                value=0,
+                tooltip={"placement": "bottom", "always_visible": True},
+                updatemode="drag",
+                persistence=True,
+                persistence_type="session",
+                id="yslider",
             ),
             html.Div(
                 [dcc.Graph(id="map")],
@@ -231,13 +293,16 @@ def waveseries_plotter_dash(model):
         Output("map", "figure"),
         Input("waveseries-1", "value"),
         Input("waveseries-2", "value"),
+        #Input("inds_slider", "value")
     )
-    def display_time_series(var1, var2):
+    def display_time_series(var1, var2):#, inds_r):
+        inds_x = 0
+        inds_y = 0
         subfig = make_subplots(specs=[[{"secondary_y": True}]])
-        fig = px.line(var, x="time", y=var1)
+        fig = px.line(df, x="time", y=var1)
         subfig.add_trace(fig.data[0], secondary_y=False)
         if var2 != "None":
-            fig2 = px.line(var, x="time", y=var2)
+            fig2 = px.line(df, x="time", y=var2)
             subfig.add_trace(fig2.data[0], secondary_y=True)
             subfig.update_traces(line_color="blue", secondary_y=False)
             subfig.update_traces(line_color="red", secondary_y=True)
@@ -253,24 +318,36 @@ def waveseries_plotter_dash(model):
             margin=dict(l=0, r=0, t=50, b=50),
         )
         fig = go.Figure(
-            go.Scattermapbox(
-                lat=ts.lat(),
-                lon=ts.lon(),
+
+        )
+        fig.add_trace(go.Scattermapbox(
+                lat=xlat,
+                lon=xlon,
                 mode="markers",
                 marker=dict(size=12),
-            )
-        )
+                name=xmodel.name
+            ))
+        if ymodel is not None:
+            fig.add_trace(go.Scattermapbox(
+                lat=ylat,
+                lon=ylon,
+                mode="markers",
+                marker=dict(size=12, color="red"),
+                name=ymodel.name
+
+            ))
+
         fig.update_layout(
             mapbox=dict(
                 style="carto-positron",
-                center=dict(lat=int(ts.lat()), lon=int(ts.lon())),
+                center=dict(lat=int(ylat), lon=int(ylon)),
                 zoom=6,
             ),
             width=450,
             height=850,
             margin=dict(l=0, r=0, t=50, b=50),
         )
-        title = f"{ts.name} Waveseries"
+        title = f"{xmodel.name} Waveseries"
         return subfig, title, fig
 
     port = random.randint(1000, 9999)
@@ -280,7 +357,7 @@ def waveseries_plotter_dash(model):
 
 def waveseries_plotter(model, model1, use_dash: bool):
     if use_dash:
-        waveseries_plotter_dash(model)
+        waveseries_plotter_dash(model, model1)
     else:
         waveseries_plotter_basic(model, model1)
 

--- a/dnplot/plot_functions/plotly_functions.py
+++ b/dnplot/plot_functions/plotly_functions.py
@@ -181,46 +181,50 @@ def waveseries_plotter_basic(model, model1):
 
 
 def waveseries_plotter_dash(model, model1):
+    def get_one_point_merged_datafram(xmodel_all, ymodel_all, inds_x, inds_y):
+        xmodel = xmodel_all.sel(inds=inds_x)
+        xdf = sanitation.xarray_to_dataframe(xmodel)
+        if ymodel_all is not None:
+            ymodel = ymodel_all.sel(inds=inds_y)
+        else:
+            ymodel = None
+       
+        if ymodel is not None:
+            ydf = sanitation.xarray_to_dataframe(ymodel)
+            xdf = xdf.set_index("time").add_suffix(f" {xmodel.name}").reset_index()
+            ydf = ydf.set_index("time").add_suffix(f" {ymodel.name}").reset_index()
+            df =  pd.merge(xdf,ydf,on="time")
+        else:
+            ydf = xdf
+            df = xdf
+
+        return xdf, ydf, df
+
+    
     xmodel_all = sanitation.force_to_ds(model)
-    
-    
     xlon, xlat = xmodel_all.lon.values, xmodel_all.lat.values
-    
     ymodel_all = sanitation.force_to_ds(model1)
-
-
-    
-    
-    xmodel = xmodel_all.sel(inds=0)
-    xdf = sanitation.xarray_to_dataframe(xmodel)
     if ymodel_all is not None:
         ylon, ylat = ymodel_all.lon.values, ymodel_all.lat.values
-        ymodel = ymodel_all.sel(inds=0)
-    else:
-        ymodel = None
-        
     
-    
-    if ymodel is not None:
-        
-        ydf = sanitation.xarray_to_dataframe(ymodel)
-        xdf = xdf.set_index("time").add_suffix(f" {xmodel.name}").reset_index()
-        ydf = ydf.set_index("time").add_suffix(f" {ymodel.name}").reset_index()
-        df =  pd.merge(xdf,ydf,on="time")
-    else:
-        ydf = xdf
-        df = xdf
-
-
+    xdf, ydf, df = get_one_point_merged_datafram(xmodel_all, ymodel_all, inds_x=0, inds_y=0)
     xvariables = [col for col in xdf if col != 'time']
     yvariables = [col for col in ydf if col != 'time']
     x_start_val = xvariables[0]
-    if ymodel is not None:
+    if ymodel_all is not None:
         y_start_val = yvariables[0]
     else:
         y_start_val = 'None'
+    if ymodel_all is not None:
+        slider_label = f"{ymodel_all.name} index"
+        slider_len = len(ylon)-1
+    else:
+        slider_label = 'Inactive'
+        slider_len=0
+
 
     app = Dash(__name__)
+
     app.layout = html.Div(
         [
             html.H1(id="title", style={"textAlign": "center"}),
@@ -249,12 +253,13 @@ def waveseries_plotter_dash(model, model1):
                     "flexDirection": "column",
                     "width": "75",
                     "float": "left",
+                    "marginTop": "200px"
                 },
             ),
-            html.Label(f"{xmodel.name}"),
+            html.Label(f"{xmodel_all.name} index"),
             dcc.Slider(
                 min=0,
-                max=len(xlon),
+                max=len(xlon)-1,
                 step=1,
                 value=0,
                 tooltip={"placement": "bottom", "always_visible": True},
@@ -263,10 +268,11 @@ def waveseries_plotter_dash(model, model1):
                 persistence_type="session",
                 id="xslider",
             ),
-            html.Label(f"{ymodel.name}"),
+
+            html.Label(slider_label),
             dcc.Slider(
                 min=0,
-                max=len(ylon),
+                max=slider_len,
                 step=1,
                 value=0,
                 tooltip={"placement": "bottom", "always_visible": True},
@@ -293,11 +299,13 @@ def waveseries_plotter_dash(model, model1):
         Output("map", "figure"),
         Input("waveseries-1", "value"),
         Input("waveseries-2", "value"),
-        #Input("inds_slider", "value")
+        Input("xslider", "value"),
+        Input("yslider", "value"),
+        Input('map','relayoutData'),
     )
-    def display_time_series(var1, var2):#, inds_r):
-        inds_x = 0
-        inds_y = 0
+    def display_time_series(var1, var2, inds_x, inds_y, relayout_data):#, inds_r):
+        
+        __, __, df = get_one_point_merged_datafram(xmodel_all, ymodel_all, inds_x, inds_y)
         subfig = make_subplots(specs=[[{"secondary_y": True}]])
         fig = px.line(df, x="time", y=var1)
         subfig.add_trace(fig.data[0], secondary_y=False)
@@ -308,10 +316,15 @@ def waveseries_plotter_dash(model, model1):
             subfig.update_traces(line_color="red", secondary_y=True)
             subfig.update_xaxes(minor=dict(ticks="inside", showgrid=True))
             subfig.update_yaxes(secondary_y=True, showgrid=False)
-            subfig.update_layout(xaxis_title="UTC", yaxis_title=var1)
+            
             subfig.update_yaxes(title_text=var2, secondary_y=True)
+
+        if ymodel_all is None:
+            subfig.update_layout(xaxis_title="UTC", yaxis_title=var1, title=f'{xmodel_all.name} (lat: {xlat[inds_x]:.3f}, lon: {xlon[inds_x]:.3f})')
         else:
-            subfig.update_layout(xaxis_title="UTC", yaxis_title=var1)
+            subfig.update_layout(xaxis_title="UTC", yaxis_title=var1, title=f'{xmodel_all.name} (lat: {xlat[inds_x]:.3f}, lon: {xlon[inds_x]:.3f}); {ymodel_all.name} (lat: {ylat[inds_y]:.3f}, lon: {ylon[inds_y]:.3f})')
+
+
         subfig.update_layout(
             width=1300,
             height=900,
@@ -321,33 +334,81 @@ def waveseries_plotter_dash(model, model1):
 
         )
         fig.add_trace(go.Scattermapbox(
-                lat=xlat,
-                lon=xlon,
-                mode="markers",
-                marker=dict(size=12),
-                name=xmodel.name
-            ))
-        if ymodel is not None:
+            lat=xlat,
+            lon=xlon,
+            mode="markers",
+            marker=dict(
+                size=12,
+                color=[
+                    "blue" if i == inds_x else "darkblue"
+                    for i in range(len(xlat))
+                ]
+            ),
+            name=xmodel_all.name
+        ))
+        if ymodel_all is not None:
             fig.add_trace(go.Scattermapbox(
                 lat=ylat,
                 lon=ylon,
                 mode="markers",
-                marker=dict(size=12, color="red"),
-                name=ymodel.name
-
+                marker=dict(
+                    size=12,
+                    color=[
+                        "red" if i == inds_y else "darkred"
+                        for i in range(len(ylat))
+                    ]
+                ),
+                name=ymodel_all.name
             ))
+
+        # Default values for zoom and center
+        zoom = 5
+        center = dict(lat=np.mean(xlat), lon=np.mean(xlon))
+
+        # Extract zoom and center from relayoutData if available
+        if relayout_data:
+            zoom = relayout_data.get("mapbox.zoom", zoom)
+            center = relayout_data.get("mapbox.center", center)
 
         fig.update_layout(
             mapbox=dict(
                 style="carto-positron",
-                center=dict(lat=int(ylat), lon=int(ylon)),
-                zoom=6,
+                zoom=zoom,
+                center=center,
             ),
-            width=450,
+            width=850,
             height=850,
             margin=dict(l=0, r=0, t=50, b=50),
         )
-        title = f"{xmodel.name} Waveseries"
+        # nonlocal first_plot
+        # if first_plot:
+        #     fig.update_layout(
+        #         mapbox=dict(
+        #             style="carto-positron",
+        #             zoom=fig.layout.mapbox.zoom if 'zoom' in fig.layout.mapbox else 6,  # Fallback to default zoom
+        #             center=fig.layout.mapbox.center if 'center' in fig.layout.mapbox else dict(lat=0, lon=0),  # Fallback to default center
+        #         ),
+        #         width=850,
+        #         height=850,
+        #         margin=dict(l=0, r=0, t=50, b=50),
+        #     )
+        #     first_plot=False
+        # else:
+        #     fig.update_layout(
+        #         mapbox=dict(
+        #             style="carto-positron",
+        #             center=fig.layout.mapbox.center,
+        #             zoom= fig.layout.mapbox.zoom
+        #         ),
+        #         width=850,
+        #         height=850,
+        #         margin=dict(l=0, r=0, t=50, b=50),
+        #     )
+        #     first_plot=False
+        if ymodel_all is not None:
+            title = f"{xmodel_all.name} and {ymodel_all.name} Waveseries"
+        else:
+            title = f"{xmodel_all.name} Waveseries"
         return subfig, title, fig
 
     port = random.randint(1000, 9999)

--- a/dnplot/plot_functions/plotly_functions.py
+++ b/dnplot/plot_functions/plotly_functions.py
@@ -251,13 +251,14 @@ def waveseries_plotter_dash(model, model1):
                 style={
                     "display": "flex",
                     "flexDirection": "column",
-                    "width": "75",
+                    "width": "75%",
                     "float": "left",
                     "marginTop": "200px"
                 },
             ),
             html.Label(f"{xmodel_all.name} index"),
-            dcc.Slider(
+            
+            html.Div([dcc.Slider(
                 min=0,
                 max=len(xlon)-1,
                 step=1,
@@ -267,10 +268,12 @@ def waveseries_plotter_dash(model, model1):
                 persistence=True,
                 persistence_type="session",
                 id="xslider",
-            ),
+ 
+            )],
+            style={'width':'75%'}),
 
             html.Label(slider_label),
-            dcc.Slider(
+            html.Div([dcc.Slider(
                 min=0,
                 max=slider_len,
                 step=1,
@@ -280,7 +283,9 @@ def waveseries_plotter_dash(model, model1):
                 persistence=True,
                 persistence_type="session",
                 id="yslider",
-            ),
+ 
+            )],
+            style={'width':'75%'}),
             html.Div(
                 [dcc.Graph(id="map")],
                 style={
@@ -326,8 +331,8 @@ def waveseries_plotter_dash(model, model1):
 
 
         subfig.update_layout(
-            width=1300,
-            height=900,
+            #width=1300,
+            #height=900,
             margin=dict(l=0, r=0, t=50, b=50),
         )
         fig = go.Figure(

--- a/dnplot/plot_functions/plotly_functions.py
+++ b/dnplot/plot_functions/plotly_functions.py
@@ -380,31 +380,7 @@ def waveseries_plotter_dash(model, model1):
             height=850,
             margin=dict(l=0, r=0, t=50, b=50),
         )
-        # nonlocal first_plot
-        # if first_plot:
-        #     fig.update_layout(
-        #         mapbox=dict(
-        #             style="carto-positron",
-        #             zoom=fig.layout.mapbox.zoom if 'zoom' in fig.layout.mapbox else 6,  # Fallback to default zoom
-        #             center=fig.layout.mapbox.center if 'center' in fig.layout.mapbox else dict(lat=0, lon=0),  # Fallback to default center
-        #         ),
-        #         width=850,
-        #         height=850,
-        #         margin=dict(l=0, r=0, t=50, b=50),
-        #     )
-        #     first_plot=False
-        # else:
-        #     fig.update_layout(
-        #         mapbox=dict(
-        #             style="carto-positron",
-        #             center=fig.layout.mapbox.center,
-        #             zoom= fig.layout.mapbox.zoom
-        #         ),
-        #         width=850,
-        #         height=850,
-        #         margin=dict(l=0, r=0, t=50, b=50),
-        #     )
-        #     first_plot=False
+
         if ymodel_all is not None:
             title = f"{xmodel_all.name} and {ymodel_all.name} Waveseries"
         else:
@@ -416,11 +392,11 @@ def waveseries_plotter_dash(model, model1):
     app.run(debug=False, port=port)
 
 
-def waveseries_plotter(model, model1, use_dash: bool):
-    if use_dash:
-        waveseries_plotter_dash(model, model1)
-    else:
+def waveseries_plotter(model, model1, plain: bool):
+    if plain:
         waveseries_plotter_basic(model, model1)
+    else:
+        waveseries_plotter_dash(model, model1)        
 
 
 def create_spectra_app_layout(

--- a/dnplot/plotters/plotters.py
+++ b/dnplot/plotters/plotters.py
@@ -8,7 +8,7 @@ from typing import Callable
 class Matplotlib:
     def __init__(self, data_dict: dict, data_dict2: dict = None):
         self.data_dict = data_dict
-        self.data_dict2 = data_dict2 or data_dict
+        self.data_dict2 = data_dict2 or {}
 
     def wavegrid(
         self,
@@ -157,9 +157,10 @@ class Matplotlib:
         self,
         var=["hs", ("tm01", "tm02"), "dirm"],
         plotter: Callable = matplotlib_functions.waveseries_plotter,
+        separate_plots: bool = None, 
         test_mode: bool = False,
     ):
-        fig_dict = plotter(self.data_dict, var)
+        fig_dict = plotter(self.data_dict, self.data_dict2, var, separate_plots)
 
     def spectra1d(
         self,
@@ -182,7 +183,8 @@ class Matplotlib:
     ):
         fig, ax = plt.subplots()
         fig_dict = {"fig": fig, "ax": ax}
-        fig_dict = plotter(fig_dict, self.data_dict, self.data_dict2, xvar, yvar)
+        data_dict2 = self.data_dict2 or self.data_dict
+        fig_dict = plotter(fig_dict, self.data_dict, data_dict2, xvar, yvar)
 
 
 
@@ -193,9 +195,9 @@ class Plotly:
         self.data_dict2 = data_dict2 or data_dict
 
     def waveseries(
-        self, use_dash, plotter: Callable = plotly_functions.waveseries_plotter
+        self, use_dash: bool=False, plotter: Callable = plotly_functions.waveseries_plotter
     ):
-        fig_dict = plotter(self.data_dict, use_dash)
+        fig_dict = plotter(self.data_dict, self.data_dict2, use_dash)
 
     def spectra(self, plotter: Callable = plotly_functions.spectra_plotter):
         fig_dict = plotter(self.data_dict)

--- a/dnplot/plotters/plotters.py
+++ b/dnplot/plotters/plotters.py
@@ -6,8 +6,9 @@ from typing import Callable
 
 
 class Matplotlib:
-    def __init__(self, data_dict: dict):
+    def __init__(self, data_dict: dict, data_dict2: dict = None):
         self.data_dict = data_dict
+        self.data_dict2 = data_dict2 or {}
 
     def wavegrid(
         self,
@@ -173,19 +174,24 @@ class Matplotlib:
             plt.show(block=True)
 
 
-class Matplotlib1:
+    def scatter(
+        self,
+        xvar="hs",
+        yvar='hs',
+        plotter: Callable = matplotlib_functions.scatter_plotter,
+    ):
+        if not self.data_dict2:
+            raise ValueError("No second data object provided at initialization!")
+        fig, ax = plt.subplots()
+        fig_dict = {"fig": fig, "ax": ax}
+        fig_dict = plotter(fig_dict, self.data_dict, self.data_dict2, xvar, yvar)
+
+
+class MatplotlibComparison:
     def __init__(self, model, model1):
         self.data_dict = model
         self.data_dict1 = model1
 
-    def scatter(
-        self,
-        var=["hs", "hs"],
-        plotter: Callable = matplotlib_functions.scatter1_plotter,
-    ):
-        fig, ax = plt.subplots()
-        fig_dict = {"fig": fig, "ax": ax}
-        fig_dict = plotter(fig_dict, self.data_dict, self.data_dict1, var)
 
 
 class Plotly:

--- a/dnplot/plotters/plotters.py
+++ b/dnplot/plotters/plotters.py
@@ -202,9 +202,9 @@ class Plotly:
         self.data_dict = data_dict
         self.data_dict2 = data_dict2 or {}
     def waveseries(
-        self, use_dash: bool=False, plotter: Callable = plotly_functions.waveseries_plotter
+        self, plain: bool=False, plotter: Callable = plotly_functions.waveseries_plotter
     ):
-        fig_dict = plotter(self.data_dict, self.data_dict2, use_dash)
+        fig_dict = plotter(self.data_dict, self.data_dict2, plain)
 
     def spectra(self, plotter: Callable = plotly_functions.spectra_plotter):
         fig_dict = plotter(self.data_dict)

--- a/dnplot/plotters/plotters.py
+++ b/dnplot/plotters/plotters.py
@@ -8,7 +8,7 @@ from typing import Callable
 class Matplotlib:
     def __init__(self, data_dict: dict, data_dict2: dict = None):
         self.data_dict = data_dict
-        self.data_dict2 = data_dict2 or {}
+        self.data_dict2 = data_dict2 or data_dict
 
     def wavegrid(
         self,
@@ -180,17 +180,10 @@ class Matplotlib:
         yvar='hs',
         plotter: Callable = matplotlib_functions.scatter_plotter,
     ):
-        if not self.data_dict2:
-            raise ValueError("No second data object provided at initialization!")
         fig, ax = plt.subplots()
         fig_dict = {"fig": fig, "ax": ax}
         fig_dict = plotter(fig_dict, self.data_dict, self.data_dict2, xvar, yvar)
 
-
-class MatplotlibComparison:
-    def __init__(self, model, model1):
-        self.data_dict = model
-        self.data_dict1 = model1
 
 
 

--- a/dnplot/plotters/plotters.py
+++ b/dnplot/plotters/plotters.py
@@ -157,10 +157,18 @@ class Matplotlib:
         self,
         var=["hs", ("tm01", "tm02"), "dirm"],
         plotter: Callable = matplotlib_functions.waveseries_plotter,
+        lon:float = None, 
+        lat:float = None, 
         separate_plots: bool = None, 
         test_mode: bool = False,
     ):
-        fig_dict = plotter(self.data_dict, self.data_dict2, var, separate_plots)
+        """var = ['hs', 'tp'] or ['hs',('tp','tm01')]
+
+        use 'separate_plots = True' to get separate figures for each parameter.
+        Default is separate_plots = True for more than 4 parameters.
+        
+        Use 'lon', 'lat' to pick a point to plot in case the data has many."""
+        fig_dict = plotter(self.data_dict, self.data_dict2, var, lon, lat, separate_plots)
 
     def spectra1d(
         self,

--- a/dnplot/plotters/plotters.py
+++ b/dnplot/plotters/plotters.py
@@ -200,8 +200,7 @@ class Matplotlib:
 class Plotly:
     def __init__(self, data_dict: dict, data_dict2: dict = None):
         self.data_dict = data_dict
-        self.data_dict2 = data_dict2 or data_dict
-
+        self.data_dict2 = data_dict2 or {}
     def waveseries(
         self, use_dash: bool=False, plotter: Callable = plotly_functions.waveseries_plotter
     ):

--- a/dnplot/plotters/plotters.py
+++ b/dnplot/plotters/plotters.py
@@ -188,8 +188,9 @@ class Matplotlib:
 
 
 class Plotly:
-    def __init__(self, model):
-        self.data_dict = model
+    def __init__(self, data_dict: dict, data_dict2: dict = None):
+        self.data_dict = data_dict
+        self.data_dict2 = data_dict2 or data_dict
 
     def waveseries(
         self, use_dash, plotter: Callable = plotly_functions.waveseries_plotter
@@ -199,11 +200,6 @@ class Plotly:
     def spectra(self, plotter: Callable = plotly_functions.spectra_plotter):
         fig_dict = plotter(self.data_dict)
 
-
-class Plotly1:
-    def __init__(self, model, model1):
-        self.data_dict = model
-        self.data_dict1 = model1
-
     def scatter(self, plotter: Callable = plotly_functions.scatter_plotter):
-        fig_dict = plotter(self.data_dict, self.data_dict1)
+        fig_dict = plotter(self.data_dict, self.data_dict2)
+

--- a/dnplot/sanitation.py
+++ b/dnplot/sanitation.py
@@ -4,7 +4,8 @@ def force_to_ds(ds):
     """Takes a dict, dnora ModelRun and gets the 'waveseries' object's xr.Dataset.
     If a geo-skeleton is given, then that dataset is returned.
     If a dataset is given, it is returned."""
-
+    if ds is None:
+        return None
     ds = ds.get('waveseries') or ds
     if not isinstance(ds,xr.Dataset):
         ds = ds.ds()

--- a/dnplot/sanitation.py
+++ b/dnplot/sanitation.py
@@ -4,7 +4,7 @@ def force_to_ds(ds):
     """Takes a dict, dnora ModelRun and gets the 'waveseries' object's xr.Dataset.
     If a geo-skeleton is given, then that dataset is returned.
     If a dataset is given, it is returned."""
-    if ds is None:
+    if not ds:
         return None
     ds = ds.get('waveseries') or ds
     if not isinstance(ds,xr.Dataset):

--- a/dnplot/sanitation.py
+++ b/dnplot/sanitation.py
@@ -1,0 +1,34 @@
+import xarray as xr
+import pandas as pd
+def force_to_ds(ds):
+    """Takes a dict, dnora ModelRun and gets the 'waveseries' object's xr.Dataset.
+    If a geo-skeleton is given, then that dataset is returned.
+    If a dataset is given, it is returned."""
+
+    ds = ds.get('waveseries') or ds
+    if not isinstance(ds,xr.Dataset):
+        ds = ds.ds()
+    return ds
+
+def get_units(ds, var:str) -> str:
+    """Takes the units from a xr.Dataset"""
+    return getattr(ds.get(var), 'units', '')
+
+def get_varname(ds, var: str) -> str:
+    """Gets a long_name, standard_name or short_name from a dataset"""
+    return (
+        getattr(ds.get(var), 'long_name', None) or
+        getattr(ds.get(var), 'standard_name', None) or
+        getattr(ds.get(var), 'short_name', var)
+    )
+
+def xarray_to_dataframe(ds) -> pd.DataFrame:
+   
+    df = ds.to_dataframe()
+    df = df.reset_index()
+    col_drop = ["lon", "lat", "inds"]
+    df = df.drop(col_drop, axis="columns")
+    df.set_index("time", inplace=True)
+    df = df.resample("h").asfreq()
+    df = df.reset_index()
+    return df

--- a/dnplot/stats.py
+++ b/dnplot/stats.py
@@ -1,0 +1,22 @@
+from sklearn.linear_model import LinearRegression
+import numpy as np
+
+def calculate_correlation(x, y):
+    x_mean = x.mean()
+    y_mean = y.mean()
+    covariance = ((x - x_mean) * (y - y_mean)).mean()
+    x_var = ((x - x_mean) ** 2).mean()
+    y_var = ((y - y_mean) ** 2).mean()
+    x_std = x_var**0.5
+    y_std = y_var**0.5
+    correlation = covariance / (x_std * y_std)
+    return correlation
+
+
+
+def calculate_RMSE(x, y):
+    x = np.asarray(x)
+    y = np.asarray(y)
+    RMSE = np.sqrt(np.mean((x-y)**2))
+    
+    return RMSE

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,16 +1,25 @@
+[build-system]
+requires = ["setuptools>=42", "wheel", "setuptools_scm"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "dnplot"
 version = "0.3.16"
 description = "Plotting of data imported by the dnora package"
 authors = [ { name = "Konstantinos Christakos", email = "konstantinosc@met.no" } , { name = "Jan-Victor Björkqvist", email = "janvb@met.no" }, {name = "Dominykas Jasas", email = "dominykas.jasas@stud.vilniustech.lt"}]
+requires-python = ">=3.9, <3.11"
 dependencies = [ "numpy", "matplotlib", "cartopy", "pandas" ,"plotly", "dash", "scipy", "cmocean", "scikit-learn" ]
 readme = "README.md"
 license = {file = "LICENSE"}
-#[project.optional-dependencies]
-#tests = [ "numpy", "xarray", "pandas", "utm", "geopy" ]
 
 [project.urls]
 repository = "http://github.com/bjorkqvi/dnplot"
 
-# [project.scripts]
-# "sfydata" = "sfy.cli.sfydata:sfy"
+[project.optional-dependencies]
+test = ["pytest>=7.0"]
+
+[tool.setuptools]
+license-files = ["LICENSE"]
+
+[tool.setuptools_scm]
+write_to = "dnplot/_version.py"


### PR DESCRIPTION
Work done on the scatter and waveseries plotters:

1. You can now give either one or two datasets directly to the Matplotlib or Plolty plotters. No need to use e.g. Plotly1 for scatters
2. If one model is given, the scatter can view a scatter of different variables inside the same dataset
3. The data given can be either a dnora `ModelRun` with a `Waveseries` object, a dictionary with a `'waveseries'` key, a geo-skeleton `PointSkeleton`, or an xarray `Dataset` (with certain constraints on the formatting, so not recommended to be used if other options are available)

For `dnplot.Matplotlib`:

- Need to specify the variables, e.g.: `dnplot.Matplotlib.scatter(xvar="hs", yvar="tp")` and `dnplot.Matplotlib.waveseries(var=['hs',('tp','tm01')])`

For `dnplot.Plotly`:

- There is no need to specify variables, since they are chosen interactively. 
- For `dnplot.Plotly.waveseries()` you can by default plot two parameters at a time, but you have sliders to choose a point and he points of both datasets are shown on a map.
- To quickly look at all the variables for a single point (but possibly two datasets), use the `plain=True` keyword.

Examples to view two wave timeseries that are in netcdf-files:

**Using dnora**

```
import dnora as dn
import dnplot

model1 = dn.modelrun.ModelRun()
model1.import_waveseries('buoy_data.nc')
model2 = dn.modelrun.ModelRun()
model2.import_waveseries('model_data.nc')

plot = dnplot.Plotly(model1, model2)
plot.waveseries()
```

**Using geo-skeletons**

```
from geo-skeletons.classes import Wave
import dnplot

buoy = Wave.add_time().from_netcdf('buoy_data.nc', name='Buoy')
model = Wave.add_time().from_netcdf('model_data.nc', name='Model')

plot = dnplot.Plotly(buoy, model)
plot.waveseries()
```
<img width="3364" height="1100" alt="Screenshot from 2025-10-02 11-48-44" src="https://github.com/user-attachments/assets/2e1ce1e2-c23b-4b8e-9079-265dc22c7875" />
